### PR TITLE
Add SDLC skills to repo instrumentation

### DIFF
--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -1,0 +1,96 @@
+# /commit
+
+Stage and commit changes following the 7 Rules of a Great Commit Message.
+
+---
+
+## Behavior
+
+### 1. Check what's changed
+
+```bash
+git diff --stat
+git status
+```
+
+Review the diff mentally. If unrelated changes are mixed in, stop and ask which files to stage.
+
+### 2. Stage selectively
+
+Stage only files related to the current issue:
+```bash
+git add <file1> <file2> ...
+```
+
+Never `git add .` blindly — verify with `git diff --cached` before committing.
+
+### 3. Write the commit message
+
+Follow the [7 Rules](https://cbea.ms/git-commit/):
+
+1. **Subject line**: imperative mood, ≤ 72 chars, no period
+2. **Blank line** between subject and body
+3. **Body**: explains *what* changed and *why* — not *how* (the diff shows how)
+
+**Template:**
+```
+<verb> <what was done>
+
+<Why this was needed. What problem it solves. Any non-obvious decisions.>
+<Reference the issue if relevant: Closes #N or Refs #N>
+```
+
+**Good examples:**
+```
+Add ConfidentialPayroll with encrypted salary storage
+
+Stores each salary as a euint64 handle. ACL grants are set at
+registration time for employer (owner) and employee wallet so
+both can decrypt via the relayer without extra steps.
+
+Closes #5
+```
+
+```
+Copy lib/confidential from PayProof reference
+
+@openzeppelin/confidential-contracts@0.3.1 requires
+@fhevm/solidity@0.9.1 as peer dep — incompatible with ^0.11.1.
+Local copy matches exactly what works on Sepolia.
+
+Closes #2
+```
+
+**Bad examples (avoid):**
+```
+fix stuff              ← vague
+WIP                    ← not a commit, use stash
+Added the contract.    ← past tense + period
+```
+
+### 4. Commit
+
+```bash
+git commit -m "<subject>" -m "<body>"
+```
+
+Or use `git commit` to open the editor for multi-line messages.
+
+### 5. Verify
+
+```bash
+git log --oneline -3
+```
+
+Confirm the message looks right. If not, amend immediately (before pushing):
+```bash
+git commit --amend
+```
+
+### 6. Handoff
+
+Report the commit hash and message.
+
+Say: "Committed. Push your branch and open a PR referencing the issue when ready."
+
+> **Note:** Do not push. The developer pushes and opens the PR — that's a human gate.

--- a/.claude/skills/implement.md
+++ b/.claude/skills/implement.md
@@ -1,0 +1,74 @@
+# /implement
+
+Execute an approved implementation plan from `/plan`. Follows the Plan → Design → Implement → Review cycle.
+
+---
+
+## Prerequisites
+
+A plan must exist and be approved before invoking this skill. If no plan is present, stop and run `/plan <issue>` first.
+
+## Behavior
+
+### 1. Confirm the plan
+
+Re-read the approved plan. Confirm:
+- All files to touch are identified
+- Steps are ordered and atomic
+- COPS-specific checklist was reviewed
+
+### 2. Execute step by step
+
+Work through each step in the plan. After each step:
+- Run the relevant check (compile, test, lint) before moving to the next
+- Do not batch steps — verify incrementally
+
+**For contracts:**
+```bash
+cd packages/hardhat && pnpm hardhat compile   # after each contract change
+cd packages/hardhat && pnpm test              # after adding tests
+```
+
+**For frontend:**
+```bash
+cd packages/nextjs && pnpm check-types        # after each TS change
+cd packages/nextjs && pnpm lint               # before committing
+```
+
+### 3. COPS contract rules (enforce on every file touched)
+
+- Import `ZamaEthereumConfig` from `@fhevm/solidity/config/ZamaConfig.sol` — inherit, never call `FHE.setCoprocessor()`
+- Use `FHE.*` namespace — never `TFHE.*`
+- `getSalary` and any function returning an encrypted handle: use `FHE.allowTransient(handle, msg.sender)` — never `FHE.sealoutput`
+- Auth on passed-in handles: `require(FHE.isAllowed(handle, msg.sender), "...")`  — never `FHE.isSenderAllowed`
+- Set ACL at every write: `FHE.allowThis` + `FHE.allow` for each authorized party
+- No salary amounts in any event — emit only addresses and metadata
+- `lib/confidential/` imports use relative paths: `../lib/confidential/token/ERC7984/...`
+
+### 4. Review your own output
+
+Before declaring done, read every file you changed:
+- Does it match the acceptance criteria from the issue?
+- Are there any TODO comments that should be addressed now vs. tracked as OQ?
+- Did you introduce any of the prohibited patterns? (run `grep -r 'TFHE\.' packages/hardhat/contracts/`)
+- Are all new functions covered by tests?
+
+### 5. Run the full verification
+
+```bash
+# Contracts
+cd packages/hardhat
+pnpm lint && pnpm test && pnpm coverage
+
+# Frontend (if applicable)
+cd packages/nextjs
+pnpm check-types && pnpm lint && pnpm test
+```
+
+All checks must pass before proceeding to `/commit`.
+
+### 6. Handoff
+
+Report: what was implemented, what tests pass, any deviations from the plan and why.
+
+Say: "Implementation complete. Run `/commit` to stage and commit."

--- a/.claude/skills/issue.md
+++ b/.claude/skills/issue.md
@@ -1,0 +1,65 @@
+# /issue
+
+Create a well-structured GitHub issue using `gh` CLI, driven by the repo's own issue templates.
+
+---
+
+## Behavior
+
+### 1. Classify
+
+Determine the issue type from the brief:
+
+- **Bug** — something broken or behaving unexpectedly → `1-bug.yml`
+- **Feature** — new capability or enhancement → `2-feature.yml`
+- **Epic** — large body of work, decomposed into smaller issues → `3-epic.yml`
+- **Spike** — time-boxed investigation to reduce uncertainty → `4-spike.yml`
+
+If unclear, ask once: *"Is this a bug, feature, epic, or spike?"*
+
+### 2. Read the template
+
+Read `.github/ISSUE_TEMPLATE/<selected>.yml`. Extract:
+- All fields (`id`, `label`, `description`, `placeholder`)
+- Which are `required: true` vs optional
+- The title prefix and label from the template header
+
+This is your source of truth for the interview and the draft. Do not invent fields that aren't in the template.
+
+### 3. Interview
+
+Ask only for what's missing. If the brief already covers a required field, don't ask again.
+
+Scale ceremony to issue weight — a small bugfix needs less interrogation than an epic. Required fields are the floor; optional fields are judgment calls based on context.
+
+### 4. Draft
+
+Produce the issue title and body. The body must mirror the template's field structure: use the field `label` as the section heading, maintain the field order, and include only sections that have content (omit empty optional fields).
+
+Show the full draft to the user before touching GitHub.
+
+### 5. Confirm
+
+Wait for explicit approval. Iterate on feedback until approved.
+
+### 6. Create
+
+Write the body to a temp file, then create the issue:
+
+```bash
+cat > /tmp/gh_issue_body.md << 'EOF'
+<body>
+EOF
+
+gh issue create \
+  --title "<prefix><title>" \
+  --label "<label>" \
+  --body-file /tmp/gh_issue_body.md
+```
+
+Optional flags when relevant:
+- `--assignee "<username>"`
+- `--milestone "<name>"`
+- `--project "<name>"`
+
+Report back with the issue URL.

--- a/.claude/skills/plan.md
+++ b/.claude/skills/plan.md
@@ -1,0 +1,70 @@
+# /plan
+
+Given a GitHub issue, produce a concrete implementation plan before touching any code.
+
+---
+
+## Behavior
+
+### 1. Read the issue
+
+Fetch the issue with:
+```bash
+gh issue view <number> --json title,body,labels
+```
+
+Extract: objective, acceptance criteria, technical notes, dependencies.
+
+### 2. Explore the codebase
+
+Read the files that will be touched. Understand existing patterns before proposing new ones. Check:
+- Relevant contracts or components already in place
+- Import paths, inheritance chains, naming conventions
+- Existing tests for the area being changed
+
+### 3. Produce the plan
+
+The plan must cover:
+
+**Approach** — one paragraph describing the overall strategy and why.
+
+**Files to create or modify** — exhaustive list with what changes in each:
+```
+packages/hardhat/contracts/ConfidentialPayroll.sol  — create
+packages/hardhat/test/ConfidentialPayroll.test.ts   — create
+```
+
+**Implementation steps** — ordered, atomic, each small enough to verify:
+```
+1. Add Employee struct and _employees[] array
+2. Implement batchAddEmployees with FHE.fromExternal per salary
+3. Set ACL: FHE.allowThis + FHE.allow(owner) + FHE.allow(wallet) per salary
+4. Implement runPayroll with cUSDC.confidentialTransferFrom loop
+5. Implement getSalary with FHE.allowTransient
+6. Write unit tests for each function
+7. Write integration test (wrap → register → run → decrypt)
+```
+
+**Edge cases and error paths** — what can go wrong, how the code handles it.
+
+**Test strategy** — which functions need unit tests, which need integration tests, what mock coprocessor setup is required.
+
+**COPS-specific checklist:**
+- [ ] No `TFHE.*` anywhere
+- [ ] `ZamaEthereumConfig` in inheritance, not `FHE.setCoprocessor()`
+- [ ] `FHE.allowTransient` for returned handles, not `sealoutput`
+- [ ] `FHE.isAllowed(handle, msg.sender)` for auth checks
+- [ ] ACL set at write time (`allowThis` + `allow` for each authorized party)
+- [ ] No amounts in events
+
+### 4. Show and wait
+
+Present the full plan. Do NOT write any code until the user approves.
+
+If the plan reveals a blocker (missing dependency, unclear spec), surface it now — not after coding starts.
+
+### 5. On approval
+
+Say: "Plan approved. Ready to implement — run `/implement` to execute."
+
+Do NOT start implementing in this skill. `/implement` is the next step.

--- a/.claude/skills/pre-review.md
+++ b/.claude/skills/pre-review.md
@@ -1,0 +1,91 @@
+# /pre-review
+
+Review your own local diff before opening a PR. Catch issues before reviewers see them.
+
+---
+
+## Behavior
+
+### 1. Get the diff
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD
+```
+
+If the branch isn't pushed yet:
+```bash
+git diff main...HEAD
+```
+
+### 2. Run all checks
+
+```bash
+# Contracts
+cd packages/hardhat && pnpm lint && pnpm test && pnpm coverage
+
+# Frontend (if changed)
+cd packages/nextjs && pnpm check-types && pnpm lint && pnpm test
+```
+
+All must pass. If any fail, stop — fix before reviewing.
+
+### 3. Review the diff against the issue
+
+Fetch the linked issue:
+```bash
+gh issue view <number>
+```
+
+Check each acceptance criterion:
+- [ ] Is it implemented?
+- [ ] Is it tested?
+- [ ] Is it documented (if needed)?
+
+### 4. COPS contract audit
+
+Run for every contract file touched:
+
+```bash
+grep -r 'TFHE\.'          packages/hardhat/contracts/  # must be empty
+grep -r 'setCoprocessor'  packages/hardhat/contracts/  # must be empty
+grep -r 'sealoutput'      packages/hardhat/contracts/  # must be empty
+grep -r 'isSenderAllowed' packages/hardhat/contracts/  # must be empty
+```
+
+Check each contract inherits `ZamaEthereumConfig`:
+```bash
+grep -r 'ZamaEthereumConfig' packages/hardhat/contracts/
+```
+
+### 5. General code review
+
+Flag any of the following:
+- Commented-out code left in
+- TODO comments that should be tracked as issues (not buried in code)
+- Functions > 100 lines
+- Missing error messages on `require` / `revert`
+- Hardcoded addresses or values that should be env vars
+- Unhandled edge cases visible from the diff
+
+### 6. Report
+
+Produce a structured report:
+
+```
+## Pre-review report
+
+**Checks:** ✅ lint / ✅ tests / ✅ coverage / ✅ types
+
+**Acceptance criteria:**
+- [x] <criterion 1>
+- [x] <criterion 2>
+- [ ] <criterion 3> — NOT MET: <explanation>
+
+**Issues found:**
+- <file>:<line> — <description>
+
+**Verdict:** Ready to open PR / Needs fixes first
+```
+
+If verdict is "Needs fixes", describe each fix concisely. Do not open the PR until all are resolved.

--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: Report a bug or unexpected behavior.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Before opening a new issue, please search existing issues to avoid duplicates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+      description: What did you expect to happen, and what actually happened?
+      placeholder: |
+        **Expected:** ...
+        **Actual:** ...
+    validations:
+      required: true
+
+  - type: input
+    id: reproduction
+    attributes:
+      label: Reproduction link
+      description: Link to a minimal reproduction (repo, sandbox, deploy). Issues without a reproduction may be closed.
+      placeholder: https://github.com/...
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Relevant environment details (OS, browser, runtime, package versions).
+      render: bash
+      placeholder: |
+        OS: macOS 15.3
+        Node: 22.x
+        Package: 1.0.0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How much does this impact your work?
+      options:
+        - Low — cosmetic or minor inconvenience
+        - Medium — broken feature, workaround exists
+        - High — broken feature, no workaround
+        - Critical — system down, data loss, or security issue
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, error messages, or anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,0 +1,68 @@
+name: Feature
+description: Propose a new feature or enhancement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a feature request, please check if a similar one already exists.
+
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User story / Problem statement
+      description: Who needs this and why? A user story format works well, but a clear problem statement is just as good.
+      placeholder: |
+        As a [role], I want [goal], so that [benefit].
+
+        — or —
+
+        Currently, ... This is a problem because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior or approach.
+      placeholder: What should happen? How should it work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Testable conditions that define "done". These will be mirrored in the PR checklist.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you explored and why they were discarded.
+    validations:
+      required: false
+
+  - type: textarea
+    id: technical-notes
+    attributes:
+      label: Technical notes
+      description: Architecture considerations, dependencies, migration concerns, or anything the implementer should know.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots, references, or related issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-epic.yml
+++ b/.github/ISSUE_TEMPLATE/3-epic.yml
@@ -1,0 +1,98 @@
+name: Epic
+description: Define a large body of work that will be broken into smaller issues.
+title: "[Epic]: "
+labels: ["epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epics capture the vision and scope of a significant effort. They get decomposed into smaller, independently deliverable issues. Invest time here — the quality of the epic sets the ceiling for everything downstream.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What are we trying to achieve? The high-level goal in one or two sentences.
+      placeholder: Enable users to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: Why does this matter? Business value, user impact, or technical justification.
+      placeholder: This is important because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is in scope and, just as importantly, what is out of scope.
+      placeholder: |
+        **In scope:**
+        - ...
+
+        **Out of scope:**
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Architecture & technical considerations
+      description: Key technical decisions, patterns, constraints, or risks. Link to ADRs or design docs if they exist.
+    validations:
+      required: false
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: What blocks this epic or what does this epic block? External services, other teams, infrastructure, etc.
+    validations:
+      required: false
+
+  - type: textarea
+    id: issues
+    attributes:
+      label: Issue breakdown
+      description: Checklist of sub-issues that compose this epic. Can start as a rough draft — the agent or the team will refine and create the actual issues.
+      placeholder: |
+        - [ ] #issue or description
+        - [ ] #issue or description
+        - [ ] #issue or description
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this epic is done? High-level conditions, not per-issue details.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: input
+    id: owner
+    attributes:
+      label: Owner / DRI
+      description: Who is responsible for driving this epic to completion?
+      placeholder: "@username"
+    validations:
+      required: false
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Target milestone
+      description: Which milestone or release is this epic targeting?
+      placeholder: v1.0, Q2 2026, Sprint 5...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/4-spike.yml
+++ b/.github/ISSUE_TEMPLATE/4-spike.yml
@@ -1,0 +1,102 @@
+name: Spike / Research
+description: Time-boxed investigation to answer a question or reduce uncertainty.
+title: "[Spike]: "
+labels: ["spike"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A spike is not about delivering code — it's about answering a question. Define the question clearly, time-box the effort, and document findings here. The issue itself becomes the deliverable.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Research question
+      description: What question(s) are we trying to answer? Be specific.
+      placeholder: |
+        Can we use X to solve Y?
+        What are the trade-offs between A and B for our use case?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: timebox
+    attributes:
+      label: Time-box
+      description: Maximum time to spend before reporting back, regardless of outcome.
+      options:
+        - 2 hours
+        - Half day
+        - 1 day
+        - 2 days
+        - 3 days
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background / What we already know
+      description: Context, prior decisions, links to related issues or docs. Prevents the investigator from repeating work.
+    validations:
+      required: false
+
+  - type: textarea
+    id: method
+    attributes:
+      label: Investigation approach
+      description: How should this be investigated? Prototype, docs research, vendor comparison, proof of concept, talk to someone?
+      placeholder: |
+        - Read the docs for X
+        - Build a minimal prototype that tests Y
+        - Compare options A and B against criteria Z
+    validations:
+      required: false
+
+  - type: dropdown
+    id: output
+    attributes:
+      label: Expected output
+      description: What does "done" look like for this spike?
+      options:
+        - Decision (go / no-go)
+        - Technical recommendation with trade-offs
+        - Proof of concept / prototype
+        - Written summary / findings document
+        - Architecture or design proposal
+      multiple: true
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **The sections below are filled in after the investigation.**
+
+  - type: textarea
+    id: findings
+    attributes:
+      label: Findings
+      description: What did you learn? Evidence, data, demos, links.
+    validations:
+      required: false
+
+  - type: textarea
+    id: conclusions
+    attributes:
+      label: Conclusions & recommendations
+      description: Answers to the original question(s). What do you recommend and why?
+    validations:
+      required: false
+
+  - type: textarea
+    id: next-steps
+    attributes:
+      label: Next steps
+      description: Follow-up issues, decisions to make, or work to schedule based on findings.
+      placeholder: |
+        - [ ] Create issue for...
+        - [ ] Discuss with team...
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- Why this change? What problem does it solve? Link motivation, not just mechanics. -->
+
+Closes #
+
+## Changes
+
+<!-- Brief description of what was changed. Bullet points work well. -->
+
+-
+
+## Acceptance criteria
+
+<!-- Mirror the criteria from the linked issue. Check them off as you go. -->
+
+- [ ]
+
+## Test plan
+
+<!-- How was this tested? Commands, screenshots, recordings — show your work. -->
+
+## Breaking changes
+
+<!-- If none, delete this section. If any, describe what breaks and migration steps. -->
+
+None.
+
+## Checklist
+
+- [ ] Self-reviewed my own diff
+- [ ] Tests added or updated
+- [ ] Docs updated (if applicable)
+- [ ] No unrelated changes bundled in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,153 @@
+# COPS — Agent Configuration
+
+Confidential Onchain Payroll System. pnpm monorepo based on fhevm-react-template.
+Full technical spec: PRD3.md (v4.0.0).
+
+---
+
+## Stack
+
+### Contracts (`packages/hardhat/`)
+- Solidity `0.8.27`
+- `@fhevm/solidity ^0.11.1` — FHE library (`FHE.*` namespace, NOT `TFHE.*`)
+- `@openzeppelin/contracts ^5.0.2`
+- `lib/confidential/` — local copy of ERC7984 library (from PayProof reference)
+- Hardhat + `@fhevm/hardhat-plugin ^0.4.2` + `@fhevm/mock-utils 0.4.2`
+
+### Frontend (`packages/nextjs/`)
+- Next.js 15 App Router, React 19, TypeScript 5.8
+- Wagmi 2 + Viem 2 + RainbowKit
+- `@zama-fhe/relayer-sdk 0.4.1` (SepoliaConfig — built-in relayer URL)
+- `@fhevm-sdk workspace:*` — `useFHEEncryption`, `useFHEDecrypt`, `useInMemoryStorage`
+- TailwindCSS 4 + DaisyUI 5 + Zustand
+
+---
+
+## FHE Mandatory Patterns
+
+**Coprocessor init — inheritance only:**
+```solidity
+// CORRECT
+contract Foo is ZamaEthereumConfig, Ownable2Step { ... }
+
+// WRONG — does not exist
+FHE.setCoprocessor(CoprocessorSetup.defaultConfig());
+```
+
+**Imports:**
+```solidity
+import {FHE, euint64, externalEuint64, ebool} from "@fhevm/solidity/lib/FHE.sol";
+import {ZamaEthereumConfig} from "@fhevm/solidity/config/ZamaConfig.sol";
+import {ERC7984ERC20Wrapper} from "../lib/confidential/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol";
+```
+
+**Re-encryption — return handle, not sealoutput:**
+```solidity
+// CORRECT
+function getSalary(uint256 id) external returns (euint64) {
+    return FHE.allowTransient(_employees[id].salary, msg.sender);
+}
+// WRONG — FHE.sealoutput does not apply here
+```
+
+**Auth check on passed-in handles:**
+```solidity
+require(FHE.isAllowed(handle, msg.sender), "Not authorized");
+// NOT: FHE.isSenderAllowed(handle)  — does not exist
+```
+
+**ACL after every write:**
+```solidity
+FHE.allowThis(salary);
+FHE.allow(salary, owner());      // employer
+FHE.allow(salary, employeeWallet); // employee
+```
+
+**Never in contract code:**
+- `TFHE.*` — archived API
+- `FHE.setCoprocessor()` — use ZamaEthereumConfig inheritance
+- `FHE.sealoutput()` — use allowTransient
+- `FHE.isSenderAllowed()` — use FHE.isAllowed(handle, msg.sender)
+- Plaintext `uint256 salary` — always externalEuint64 → FHE.fromExternal
+- Plaintext if/else on encrypted values — use FHE.select
+
+---
+
+## Key Architecture Decisions
+
+- **Token funding**: employer calls `cUSDC.wrap(payrollContractAddress, amount)` directly — no `depositFunds()` on ConfidentialPayroll.
+- **No setPayrollContract()**: ERC7984's `isOperator(holder, spender) = true` when `holder == spender` — payroll can `confidentialTransferFrom` its own balance natively.
+- **Salary immutability**: salaries are immutable after registration. To change: deactivate + re-add.
+- **lib/confidential/**: NOT the `@openzeppelin/confidential-contracts` npm package (peer dep conflict with @fhevm/solidity@^0.11.1). Use the local copy.
+- **Target network**: Sepolia testnet (chainId 11155111).
+- **No backend**: fully client-side. Vercel static deploy.
+
+---
+
+## Contract Structure
+
+```
+packages/hardhat/
+├── contracts/
+│   ├── MockUSDC.sol
+│   ├── ConfidentialUSDC.sol      ← is ZamaEthereumConfig, ERC7984ERC20Wrapper
+│   ├── ConfidentialPayroll.sol   ← is ZamaEthereumConfig, Ownable2Step, ReentrancyGuard, Pausable
+│   └── interfaces/
+│       └── IConfidentialUSDC.sol
+└── lib/
+    └── confidential/             ← local copy (ERC7984, ERC7984ERC20Wrapper, FHESafeMath)
+```
+
+---
+
+## Testing
+
+- Framework: Hardhat + `@fhevm/mock-utils` (no Docker needed for unit tests)
+- Coverage target: ≥ 95% line coverage via `solidity-coverage`
+- Run: `cd packages/hardhat && pnpm test`
+- Coverage: `cd packages/hardhat && pnpm coverage`
+
+Frontend:
+- Framework: Vitest, colocated `*.test.ts` files
+- Run: `cd packages/nextjs && pnpm test`
+
+---
+
+## Commit Standards
+
+Follow the [7 Rules of a Great Commit Message](https://cbea.ms/git-commit/):
+1. Separate subject from body with a blank line
+2. Limit the subject line to 72 characters
+3. Use the imperative mood in the subject line
+4. Do not end the subject line with a period
+5. Use the body to explain *what* and *why*, not *how*
+
+Examples:
+```
+Add batchAddEmployees with FHE salary encryption
+
+Stores each salary as a euint64 handle with ACL grants for
+both employer and employee at registration time.
+```
+
+---
+
+## Branch Strategy
+
+```
+main          ← protected; PR + CI required
+feature/*     ← one issue = one branch = one PR
+```
+
+Naming: `feature/epic1-confidential-usdc`, `feature/epic2-csv-upload`, etc.
+Parallel workstreams: use `git worktrees`.
+
+---
+
+## PR Checklist (from .github/PULL_REQUEST_TEMPLATE.md)
+
+- Self-reviewed diff
+- Tests added or updated
+- `pnpm lint` passes
+- `pnpm check-types` passes (frontend)
+- No unrelated changes bundled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Completes the repo instrumentation bootstrap. Skills belong alongside the GitHub templates and AGENTS.md — they are the agent's toolbox from day one, not a Phase 2 add-on.

Refs #1 (Epic: Contracts) — skills will be used starting from the first implementation issue.

## Changes

- `issue.md` — copied from `bootnode-sdlc`; create structured GitHub issues via `gh` CLI driven by repo templates
- `plan.md` — given an issue, produce an implementation plan (with COPS FHE checklist) before touching code
- `implement.md` — execute an approved plan; enforces all COPS FHE guardrails per file touched
- `commit.md` — stage selectively and commit following the 7 Rules
- `pre-review.md` — self-review diff, run all checks, audit FHE patterns before opening a PR

## Acceptance criteria

- [ ] All 5 skills accessible via `/issue`, `/plan`, `/implement`, `/commit`, `/pre-review` in Claude Code
- [ ] `plan.md` and `implement.md` include COPS-specific FHE checklist
- [ ] `pre-review.md` includes `grep` commands for prohibited patterns

## Checklist

- [x] Self-reviewed my own diff
- [x] No unrelated changes bundled in