### PR TITLE
Add contract test coverage table to README

### DIFF
--- a/packages/hardhat/README.md
+++ b/packages/hardhat/README.md
@@ -88,6 +88,17 @@ fhevm-hardhat-template/
 | `npm run lint`     | Run linting checks       |
 | `npm run clean`    | Clean build artifacts    |
 
+## Test Coverage
+
+| Contract | Statements | Branches | Functions | Lines |
+|----------|-----------|----------|-----------|-------|
+| **ConfidentialPayroll.sol** | 97.37% (37/38) | 84% (42/50) | 100% (10/10) | 98.11% (52/53) |
+| **ConfidentialUSDC.sol** | 100% (2/2) | 100% (0/0) | 100% (2/2) | 100% (2/2) |
+| **MockUSDC.sol** | 100% (2/2) | 100% (0/0) | 100% (3/3) | 100% (2/2) |
+| **All contracts** | **97.62% (41/42)** | **84% (42/50)** | **100% (15/15)** | **98.25% (56/57)** |
+
+> Generated with `pnpm coverage` via solidity-coverage v0.8.17
+
 ## 📚 Documentation
 
 - [FHEVM Documentation](https://docs.zama.ai/fhevm)


### PR DESCRIPTION
## Summary
- Adds a coverage table to `packages/hardhat/README.md` with per-contract breakdown
- Generated from `pnpm coverage` (solidity-coverage v0.8.17)

| Contract | Statements | Branches | Functions | Lines |
|----------|-----------|----------|-----------|-------|
| ConfidentialPayroll.sol | 97.37% | 84% | 100% | 98.11% |
| ConfidentialUSDC.sol | 100% | 100% | 100% | 100% |
| MockUSDC.sol | 100% | 100% | 100% | 100% |
| **All contracts** | **97.62%** | **84%** | **100%** | **98.25%** |

## Test plan
- [x] `pnpm test` passes (55 passing)
- [x] Coverage numbers match `pnpm coverage` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)